### PR TITLE
enforce test coverage in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,20 +62,14 @@ jobs:
           command: |
            sudo bash -c "apt-get update && apt-get install -y default-mysql-client"
            mysql -h 127.0.0.1 -P 3306 --protocol=tcp -u ${MYSQL_USER} -p${MYSQL_PASSWORD} <./docker/init.sql
-      - run:
-          name: Unit test
-          command: go test -count=1 ./...
-      - run:
-          name: Code coverage
-          command: |
-            go test -coverprofile=coverage.out ./...
-            go tool cover -html=coverage.out -o coverage.html
+      - run: sudo apt install bc
+      - run: ./scripts/test_coverage.sh
       - run:
           name: "RunSonarqube scanner"
           command: |
             export SCAN_VERSION=4.3.0.2102-linux
-            wget https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SCAN_VERSION}.zip 
-            unzip sonar-scanner-cli-${SCAN_VERSION}.zip 
+            wget https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SCAN_VERSION}.zip
+            unzip sonar-scanner-cli-${SCAN_VERSION}.zip
             ./sonar-scanner-${SCAN_VERSION}/bin/sonar-scanner \
              -Dsonar.projectKey=gitwize-be \
              -Dsonar.sources=. \

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ _testmain.go
 /test/run.out
 /test/times.out
 
+percentage.txt
+
 .idea
 # This file includes artifacts of Go build that should not be checked in.
 # For files created by specific development environment (e.g. editor),

--- a/scripts/test_coverage.sh
+++ b/scripts/test_coverage.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+go test ./...  -coverprofile cover.out; go tool cover -func cover.out | grep -o '[^,]\+$' | grep total |  awk '{print substr($3, 1, length($3)-1)}' > percentage.txt
+
+percentage=$(cat percentage.txt)
+
+echo "total coverage ${percentage}%"
+
+if [[ "$(echo "${percentage} < ${GITWIZE_TEST_COVERAGE}" | bc)" -ne 0 ]]
+then
+    echo "Test coverage failed. Expected ${GITWIZE_TEST_COVERAGE}% , got ${percentage}%."
+    exit 1
+fi


### PR DESCRIPTION
### What does this PR do?
Test coverage for whole repo should reach target as defined in `${GITWIZE_TEST_COVERAGE}`
If not CI build will fail and notify

